### PR TITLE
feat: allow to pass href to render native anchors on buttons

### DIFF
--- a/components/base/BaseButton.vue
+++ b/components/base/BaseButton.vue
@@ -9,6 +9,9 @@ const props = withDefaults(
     /** The location to which the button should navigate when clicked. This is only applicable if the button is a link. */
     to?: RouteLocationRaw
 
+    /** Using href instead of to result in a native anchor with no router functionality. */
+    href?: string
+
     /** Whether the button should be disabled. */
     disabled?: boolean
 
@@ -54,6 +57,7 @@ const props = withDefaults(
     shape: undefined,
     type: undefined,
     to: undefined,
+    href: undefined,
     disabled: false,
     shadow: undefined,
     rel: '',
@@ -423,7 +427,7 @@ const colorStyle = computed(() => {
 const classes = computed(() => [
   props.condensed ? 'is-button-condensed' : 'is-button',
   props.loading && '!text-transparent',
-  shapeStyle[shape.value],
+  shape.value && shapeStyle[shape.value],
   ...colorStyle.value[props.color],
   props.flavor === 'solid' &&
     (props.shadow === 'flat'

--- a/components/base/BaseButtonAction.vue
+++ b/components/base/BaseButtonAction.vue
@@ -13,6 +13,9 @@ const props = withDefaults(
      */
     to?: RouteLocationRaw
 
+    /** Using href instead of to result in a native anchor with no router functionality. */
+    href?: string
+
     /**
      * Whether the button is disabled.
      */
@@ -54,6 +57,7 @@ const props = withDefaults(
   {
     shape: undefined,
     to: undefined,
+    href: undefined,
     target: '',
     rel: '',
     color: 'default',
@@ -184,6 +188,7 @@ const colorStyle = {
   ],
   none: [''],
   default: [''],
+  muted: [''],
 }
 
 const colorClass = computed(() =>
@@ -225,7 +230,7 @@ const buttonClasses = computed(() => [
   'disabled:opacity-60 disabled:cursor-not-allowed hover:enabled:shadow-none',
   props.loading && '!text-transparent',
   ...colorClass.value,
-  shapeStyle[shape.value],
+  shape.value && shapeStyle[shape.value],
 ])
 
 const { attributes, is } = useNinjaButton(props)

--- a/components/base/BaseButtonIcon.vue
+++ b/components/base/BaseButtonIcon.vue
@@ -15,6 +15,9 @@ const props = withDefaults(
      */
     to?: RouteLocationRaw
 
+    /** Using href instead of to result in a native anchor with no router functionality. */
+    href?: string
+
     /**
      * Whether the button or link is disabled.
      */
@@ -56,6 +59,7 @@ const props = withDefaults(
     color: 'default',
     shape: undefined,
     to: undefined,
+    href: undefined,
     type: undefined,
     rel: '',
     target: '',
@@ -95,7 +99,7 @@ const iconButtonClasses = computed(() => [
   'disabled:opacity-60 disabled:cursor-not-allowed hover:shadow-none',
   props.loading ? '!text-transparent' : '',
   colorClass.value,
-  shapeStyle[shape.value],
+  shape.value && shapeStyle[shape.value],
   sizeClass.value,
 ])
 

--- a/components/base/BaseDropdownItem.vue
+++ b/components/base/BaseDropdownItem.vue
@@ -13,6 +13,9 @@ const props = defineProps<{
    */
   to?: RouteLocationRaw
 
+  /** Using href instead of to result in a native anchor with no router functionality. */
+  href?: string
+
   /**
    * Whether the button is disabled.
    */

--- a/composables/buttons.ts
+++ b/composables/buttons.ts
@@ -3,6 +3,7 @@ import type { RouteLocationRaw } from 'vue-router'
 export interface BaseButtonProperties {
   type?: 'button' | 'submit' | 'reset'
   to?: RouteLocationRaw
+  href?: string
   disabled?: boolean
   rel?: string
   target?: string
@@ -18,7 +19,9 @@ export const useNinjaButton = (
 ) => {
   const NuxtLink = defineNuxtLink({})
 
-  const is = computed(() => (properties.to ? NuxtLink : 'button'))
+  const is = computed(() =>
+    properties.to ? NuxtLink : properties.href ? 'a' : 'button'
+  )
   const type = computed(() => {
     if (is.value === 'button') {
       return properties.type || 'button'


### PR DESCRIPTION
When a `href` props is passed to `<BaseButton>`/`<BaseButtonAction>`/`<BaseButtonIcon>`/`<BaseDropdownItem>` the element renders an anchor instead of a `<NuxtLink>`/`<button>`