### PR TITLE
Fix clash between v-bind="field" and v-model when using vee-validate.

### DIFF
--- a/components/form/BaseInput.vue
+++ b/components/form/BaseInput.vue
@@ -145,6 +145,10 @@ function looseToNumber(val: any) {
   return Number.isNaN(n) ? val : n
 }
 
+// Only bind v-model to the input if a modelValue is present in the props.
+// This prevents conflicts when using v-bind="field" from vee-validate.
+const vModelOnInput = !!props.modelValue ? 'value' : '_unused'
+
 const value = useVModel(props, 'modelValue', (_, val) => {
   if (props.modelModifiers.number) {
     emits('update:modelValue', looseToNumber(val))
@@ -227,8 +231,9 @@ if (process.dev) {
       <input
         :id="id"
         ref="inputRef"
-        v-model="value"
         :type="props.type"
+        v-bind:[vModelOnInput]="value"
+        @input="value = ($event.target as HTMLInputElement).value"
         v-bind="$attrs"
         class="nui-focus border-muted-300 text-muted-600 placeholder:text-muted-300 dark:border-muted-700 dark:bg-muted-900/75 dark:text-muted-200 dark:placeholder:text-muted-500 dark:focus:border-muted-700 peer w-full border bg-white font-sans transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-75"
         :class="[


### PR DESCRIPTION
I noticed that VeeValidate recommends to not use v-bind="field" combined with v-model, here: https://vee-validate.logaretm.com/v4/api/field/.

Due to the way `BaseInput` is set up, it's not possible to use a v-bind, because the BaseInput is **always** setting v-model on the input internally. 

It would be nice if we could do something like this:

```
<Field v-slot="{ field, errorMessage }" name="email">
  <BaseInput
    icon="lucide:mail"
    v-bind="field"
    :error="errorMessage"
    type="email"
    label="E-mail address"
  />
</Field>
```

Instead of this:

```
<Field
  v-slot="{ field, errorMessage, handleChange, handleBlur }"
  name="email"
>
  <BaseInput
    icon="lucide:mail"
    :model-value="field.value"
    :error="errorMessage"
    type="email"
    label="Email address"
    @update:model-value="handleChange"
    @blur="handleBlur"
  />
</Field>
```

I believe a possible solution is to disable the v-model in BaseInput when v-bind is being used. I've solved it by checking if a props.modelValue is being set. Although that might be a bit hacky solution. Please let me know if you have other ideas. I might need to spend a bit more time on it.

I also need to do a bit more testing on it, but wanted to share it with you guys.