### PR TITLE
feat(BaseListbox): allow value prop as model with v-model.prop

### DIFF
--- a/.playground/pages/tests/form/listbox.vue
+++ b/.playground/pages/tests/form/listbox.vue
@@ -2,7 +2,8 @@
 definePageMeta({
   title: 'Listbox',
   icon: 'ic:round-menu-open',
-  description: 'SVG icons',
+  description:
+    'Test use of both objects and object value props in listbox models',
   section: 'form',
 })
 const frameworks = [

--- a/.playground/pages/tests/form/listbox.vue
+++ b/.playground/pages/tests/form/listbox.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+definePageMeta({
+  title: 'Listbox',
+  icon: 'ic:round-menu-open',
+  description: 'SVG icons',
+  section: 'form',
+})
+const frameworks = [
+  { label: 'React', value: 'react' },
+  { label: 'Vue', value: 'vue' },
+  { label: 'Angular', value: 'angular' },
+  { label: 'Svelte', value: 'svelte' },
+]
+const model = ref({
+  frameworkId: '',
+  framework: {},
+})
+const properties = {
+  value: 'value',
+  label: 'label',
+}
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-12 [&>*]:p-8 [&>:nth-child(odd)]:bg-muted-100 dark:[&>:nth-child(odd)]:bg-muted-900 pb-32"
+  >
+    <div>
+      <BaseHeading size="xl" weight="medium" class="mb-10">
+        Default Listbox
+      </BaseHeading>
+      <div class="grid grid-cols-3 gap-4">
+        <BaseListbox
+          v-model="model.framework"
+          :items="frameworks"
+          :properties="properties"
+        />
+        <pre> {{ model }}</pre>
+        <BaseButton @click="model.framework = frameworks[1]">
+          Set Framework to Vue
+        </BaseButton>
+      </div>
+    </div>
+
+    <div>
+      <BaseHeading size="xl" weight="medium" class="mb-10">
+        Listbox with Object Key
+      </BaseHeading>
+      <div class="grid grid-cols-3 gap-4">
+        <BaseListbox
+          v-model="model.frameworkId"
+          :items="frameworks"
+          :properties="properties"
+          return-value-prop
+        />
+        <pre> {{ model }}</pre>
+        <BaseButton @click="model.frameworkId = 'vue'">
+          Set Framework to Vue
+        </BaseButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/.playground/pages/tests/form/listbox.vue
+++ b/.playground/pages/tests/form/listbox.vue
@@ -49,10 +49,9 @@ const properties = {
       </BaseHeading>
       <div class="grid grid-cols-3 gap-4">
         <BaseListbox
-          v-model="model.frameworkId"
+          v-model.prop="model.frameworkId"
           :items="frameworks"
           :properties="properties"
-          return-value-prop
         />
         <pre> {{ model }}</pre>
         <BaseButton @click="model.frameworkId = 'vue'">

--- a/components/form/BaseListbox.vue
+++ b/components/form/BaseListbox.vue
@@ -113,6 +113,11 @@ const props = withDefaults(
        */
       icon?: string
     }
+
+    /**
+     * Set this to only return the value property of an object (as defined in properties.value) rather than the object itself
+     */
+    returnValueProp?: boolean
   }>(),
   {
     icon: '',
@@ -139,6 +144,7 @@ const props = withDefaults(
     loading: false,
     disabled: false,
     properties: () => ({}),
+    returnValueProp: false,
   }
 )
 const emits = defineEmits<{
@@ -166,7 +172,7 @@ const contrastStyle = {
   'muted-contrast': 'nui-listbox-muted-contrast',
 }
 
-const value = useVModel(props, 'modelValue', emits)
+const vmodel = useVModel(props, 'modelValue', emits)
 
 const placeholder = computed(() => {
   if (props.loading) {
@@ -177,6 +183,14 @@ const placeholder = computed(() => {
   }
 
   return props.placeholder
+})
+
+const value = computed(() => {
+  if (props.returnValueProp && props.properties.value) {
+    const attr = props.properties.value
+    return props.items.find((i) => i[attr] === props.modelValue)
+  }
+  return props.modelValue
 })
 </script>
 
@@ -195,8 +209,8 @@ const placeholder = computed(() => {
   >
     <Listbox
       v-slot="{ open }: { open: boolean }"
-      v-model="value"
-      :by="props.properties.value"
+      v-model="vmodel"
+      :by="returnValueProp ? undefined : props.properties.value"
       :multiple="props.multiple"
       :disabled="props.disabled"
     >
@@ -313,7 +327,11 @@ const placeholder = computed(() => {
               :key="
                 props.properties.value ? item[props.properties.value] : item
               "
-              :value="item"
+              :value="
+                returnValueProp && props.properties.value
+                  ? item[props.properties.value]
+                  : item
+              "
               as="template"
             >
               <li

--- a/components/form/BaseListbox.vue
+++ b/components/form/BaseListbox.vue
@@ -16,8 +16,20 @@ const props = withDefaults(
 
     /**
      * The model value of the multiselect.
+     *
+     * @modifiers
+     * `v-model="value"`
+     *
+     * @modifiers
+     * the value property of an object (as defined in properties.value) rather than the object itself
+     * `v-model.prop="value"`
      */
-    modelValue: any
+    modelValue?: any
+
+    /**
+     * Used internaly to allow v-model.number and v-model.trim
+     */
+    modelModifiers?: any
 
     /**
      * The shape of the multiselect.
@@ -113,14 +125,11 @@ const props = withDefaults(
        */
       icon?: string
     }
-
-    /**
-     * Set this to only return the value property of an object (as defined in properties.value) rather than the object itself
-     */
-    returnValueProp?: boolean
   }>(),
   {
     icon: '',
+    modelValue: undefined,
+    modelModifiers: () => ({}),
     selectedIcon: 'lucide:check',
     label: '',
     placeholder: '',
@@ -144,7 +153,6 @@ const props = withDefaults(
     loading: false,
     disabled: false,
     properties: () => ({}),
-    returnValueProp: false,
   }
 )
 const emits = defineEmits<{
@@ -172,7 +180,9 @@ const contrastStyle = {
   'muted-contrast': 'nui-listbox-muted-contrast',
 }
 
-const vmodel = useVModel(props, 'modelValue', emits)
+const vmodel = useVModel(props, 'modelValue', emits, {
+  passive: true,
+})
 
 const placeholder = computed(() => {
   if (props.loading) {
@@ -186,7 +196,7 @@ const placeholder = computed(() => {
 })
 
 const value = computed(() => {
-  if (props.returnValueProp && props.properties.value) {
+  if (props.modelModifiers.prop && props.properties.value) {
     const attr = props.properties.value
     return props.items.find((i) => i[attr] === props.modelValue)
   }
@@ -210,7 +220,7 @@ const value = computed(() => {
     <Listbox
       v-slot="{ open }: { open: boolean }"
       v-model="vmodel"
-      :by="returnValueProp ? undefined : props.properties.value"
+      :by="props.modelModifiers.prop ? undefined : props.properties.value"
       :multiple="props.multiple"
       :disabled="props.disabled"
     >
@@ -328,7 +338,7 @@ const value = computed(() => {
                 props.properties.value ? item[props.properties.value] : item
               "
               :value="
-                returnValueProp && props.properties.value
+                props.modelModifiers.prop && props.properties.value
                   ? item[props.properties.value]
                   : item
               "


### PR DESCRIPTION
I need to use object ids in my listboxes, so I added this feature.  Thought it'd be a nice addition.

Also added a test page to verify this works as expected.

I coded it as a non-breaking change.  