### PR TITLE
fix: modelValue type on autocomplete

### DIFF
--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -18,7 +18,7 @@ const props = withDefaults(
     /**
      * The model value of the component.
      */
-    modelValue?: any[]
+    modelValue?: any | any[]
 
     /**
      * The items to display in the component.


### PR DESCRIPTION
component emits type of `any | any[]` causing type errors

```
const emits = defineEmits<{
  (event: 'update:modelValue', value?: any | any[]): void
}>()
```