### PR TITLE
feat: add fixed mode and more generic BaseAutocompleteItem

### DIFF
--- a/components/base/BaseDropdown.vue
+++ b/components/base/BaseDropdown.vue
@@ -49,6 +49,10 @@ const props = withDefaults(
      * @deprecated use placement instead
      */
     orientation?: 'start' | 'end'
+    /**
+     * Used a fixed strategy to float the component
+     */
+    fixed?: boolean
 
     /**
      * The placement of the dropdown via floating-ui.
@@ -92,6 +96,7 @@ const props = withDefaults(
     color: 'white',
     label: '',
     headerLabel: undefined,
+    fixed: false,
   },
 )
 
@@ -153,7 +158,9 @@ const placementValue = computed(() => {
         leave-to-class="transform scale-95 opacity-0"
         flip
         :offset="props.flavor === 'context' ? 6 : 4"
+        :strategy="props.fixed ? 'fixed' : 'absolute'"
         :placement="placementValue"
+        :adaptive-width="props.fixed"
         :z-index="20"
       >
         <MenuButton as="template">

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts" generic="T extends any = string">
+import { Float, FloatContent, FloatReference } from '@headlessui-float/vue'
 import {
   Combobox,
   ComboboxButton,
@@ -7,7 +8,6 @@ import {
   ComboboxOption,
   ComboboxOptions,
 } from '@headlessui/vue'
-import { Float, FloatReference, FloatContent } from '@headlessui-float/vue'
 
 const props = withDefaults(
   defineProps<{
@@ -234,20 +234,9 @@ const props = withDefaults(
     dropdownIcon: 'lucide:chevron-down',
     dropdown: false,
     multiple: false,
-    displayValue: (item: any) => item,
+    displayValue: undefined,
     filterDebounce: 0,
-    filterItems: (query?: string, items?: T[]) => {
-      if (!query || !items) {
-        return items ?? []
-      }
-
-      return items.filter((item) => {
-        if (typeof item !== 'string') {
-          return false
-        }
-        return item?.toLowerCase().includes(query.toLowerCase())
-      })
-    },
+    filterItems: undefined,
     classes: () => ({}),
     allowCustom: false,
     fixed: false,
@@ -260,6 +249,52 @@ const emits = defineEmits<{
   (event: 'update:modelValue', value?: T | T[]): void
   (event: 'keydown', value: KeyboardEvent): void
 }>()
+
+const defaultDisplayValue = (item: any): any => {
+  if (typeof item === 'string') return item
+  if (
+    typeof item === 'object' &&
+    props.properties?.label &&
+    props.properties.label in item
+  )
+    return item[props.properties.label]
+
+  return item
+}
+
+const defaultFilter = (query?: string, items?: T[]): T[] => {
+  if (!query || !items) {
+    return items ?? []
+  }
+
+  const lower = query.toLowerCase()
+
+  return items.filter((item: any) => {
+    if (typeof item === 'string') return item?.toLowerCase().includes(lower)
+    if (
+      typeof item === 'object' &&
+      props.properties?.label &&
+      props.properties.label in item
+    )
+      return item[props.properties.label].toLowerCase().includes(lower)
+    if (
+      typeof item === 'object' &&
+      props.properties?.sublabel &&
+      props.properties.sublabel in item
+    )
+      return item[props.properties.sublabel].toLowerCase().includes(lower)
+  })
+}
+
+const filterResolved = computed(() => {
+  if (props.filterItems === undefined) return defaultFilter
+  return props.filterItems
+})
+const displayValueResolved = computed(() => {
+  if (props.displayValue === undefined) return defaultDisplayValue
+  return props.displayValue
+})
+
 const appConfig = useAppConfig()
 const shape = computed(() => props.shape ?? appConfig.nui.defaultShapes?.input)
 
@@ -270,9 +305,9 @@ const value = useVModel(props, 'modelValue', emits, {
 const items = shallowRef(props.items)
 const query = ref('')
 const debounced = refDebounced(query, props.filterDebounce)
-const filteredItems = shallowRef<Awaited<ReturnType<typeof props.filterItems>>>(
-  props.dropdown ? props.items : [],
-)
+const filteredItems = shallowRef<
+  Awaited<ReturnType<typeof filterResolved.value>>
+>(props.dropdown ? props.items : [])
 const pendingFilter = ref(false)
 const pendingDebounce = computed(() => query.value !== debounced.value)
 const pending = computed(() => pendingFilter.value || pendingDebounce.value)
@@ -341,7 +376,7 @@ defineExpose({
 watch(debounced, async (value) => {
   pendingFilter.value = true
   try {
-    filteredItems.value = await props.filterItems(value, items.value)
+    filteredItems.value = await filterResolved.value(value, items.value)
   } catch (error: any) {
     if (error?.name === 'AbortError') {
       // Ignore abort errors
@@ -386,13 +421,13 @@ function removeItem(item: any) {
 }
 
 function key(item: T) {
-  if (props.properties == null) return props.displayValue(item)
+  if (props.properties == null) return displayValueResolved.value(item)
   if (typeof props.properties.key === 'string')
     return (item as any)[props.properties.key]
   if (typeof props.properties.key === 'function')
     //@ts-expect-error not sure why properties.key ends up undefined
     return props.properties.key(item as any)
-  return props.displayValue(item)
+  return displayValueResolved.value(item)
 }
 </script>
 
@@ -424,7 +459,7 @@ function key(item: T) {
       :strategy="props.fixed ? 'fixed' : 'absolute'"
       :placement="props.placement"
       :adaptive-width="props.fixed"
-      :z-index="20"
+      :z-index="200"
     >
       <ComboboxLabel
         v-if="
@@ -446,7 +481,7 @@ function key(item: T) {
         >
           <li v-for="item in value" :key="String(item)">
             <div class="nui-autocomplete-multiple-list-item">
-              {{ props.displayValue(item) }}
+              {{ displayValueResolved(item) }}
               <button type="button" @click="removeItem(item)">
                 <slot name="chip-clear-icon">
                   <Icon
@@ -463,9 +498,9 @@ function key(item: T) {
         <div class="nui-autocomplete-outer">
           <ComboboxInput
             class="nui-autocomplete-input"
-            :class="classes?.input"
+            :class="[classes?.input, props.dropdown && '!pe-8']"
             :display-value="
-              props.multiple ? undefined : (props.displayValue as any)
+              props.multiple ? undefined : (displayValueResolved as any)
             "
             :placeholder="props.placeholder"
             :disabled="props.disabled"
@@ -619,7 +654,7 @@ function key(item: T) {
                     properties
                       ? item
                       : ({
-                          label: props.displayValue(item),
+                          label: displayValueResolved(item),
                         } as T)
                   "
                   :active="active"

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -607,6 +607,7 @@ function key(item: T) {
             </slot>
           </button>
           <ComboboxButton
+            v-if="props.dropdown"
             v-slot="{ open }: { open: boolean }"
             class="nui-autocomplete-clear nui-autocomplete-chevron"
           >

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -537,7 +537,11 @@ function key(item: T) {
           props.portal && shape && shapeStyle[shape],
         ]"
       >
-        <ComboboxOptions as="div" class="nui-autocomplete-results">
+        <ComboboxOptions
+          as="div"
+          class="nui-autocomplete-results"
+          :unmount="!portal"
+        >
           <!-- Placeholder -->
           <div
             v-if="filteredItems.length === 0 && pending"

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -161,9 +161,26 @@ const props = withDefaults(
     allowCustom?: boolean
 
     /**
-     * Portal the dropdown to body
+     * Used a fixed strategy to float the component
      */
-    portal?: boolean
+    fixed?: boolean
+
+    /**
+     * The placement of the component via floating-ui.
+     */
+    placement?:
+      | 'top'
+      | 'top-start'
+      | 'top-end'
+      | 'right'
+      | 'right-start'
+      | 'right-end'
+      | 'bottom'
+      | 'bottom-start'
+      | 'bottom-end'
+      | 'left'
+      | 'left-start'
+      | 'left-end'
 
     /**
      * The properties to use for the value, label, sublabel, media, and icon of the options items.
@@ -233,8 +250,9 @@ const props = withDefaults(
     },
     classes: () => ({}),
     allowCustom: false,
-    portal: false,
-    properties: undefined,
+    fixed: false,
+    placement: 'bottom-start',
+    properties: () => ({}),
   },
 )
 
@@ -403,8 +421,9 @@ function key(item: T) {
       @hide="query = ''"
       :flip="!props.multiple"
       :offset="5"
-      :portal="props.portal"
-      :adaptive-width="props.portal"
+      :strategy="props.fixed ? 'fixed' : 'absolute'"
+      :placement="props.placement"
+      :adaptive-width="props.fixed"
       :z-index="20"
     >
       <ComboboxLabel
@@ -516,22 +535,13 @@ function key(item: T) {
       >
         {{ props.error }}
       </span>
-      <FloatContent
-        :class="[
-          !props.portal && 'w-full',
-          props.portal && 'nui-autocomplete',
-          props.portal && sizeStyle[props.size],
-          props.portal && contrastStyle[props.contrast],
-          props.portal && shape && shapeStyle[shape],
-        ]"
-      >
+      <FloatContent :class="!props.fixed && 'w-full'">
         <ComboboxOptions
           as="div"
           :class="{
             'nui-autocomplete-results':
               filteredItems.length > 0 || !allowCustom,
           }"
-          :unmount="!portal"
         >
           <!-- Placeholder -->
           <div

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -259,6 +259,10 @@ const pendingFilter = ref(false)
 const pendingDebounce = computed(() => query.value !== debounced.value)
 const pending = computed(() => pendingFilter.value || pendingDebounce.value)
 
+const queryCustom = computed(() => {
+  return query.value === '' ? null : query.value
+})
+
 const shapeStyle = {
   straight: '',
   rounded: 'nui-autocomplete-rounded',
@@ -348,22 +352,6 @@ const iconResolved = computed(() => {
   }
   return props.icon
 })
-
-function isAutocompleteItem(
-  item: unknown,
-): item is Record<'name' | 'text' | 'media' | 'icon', string> {
-  if (
-    item &&
-    typeof item === 'object' &&
-    (('name' in item && typeof item.name === 'string') ||
-      ('text' in item && typeof item.text === 'string') ||
-      ('media' in item && typeof item.media === 'string') ||
-      ('icon' in item && typeof item.icon === 'string'))
-  ) {
-    return true
-  }
-  return false
-}
 
 function removeItem(item: any) {
   if (!Array.isArray(value.value)) {
@@ -539,7 +527,10 @@ function key(item: T) {
       >
         <ComboboxOptions
           as="div"
-          class="nui-autocomplete-results"
+          :class="{
+            'nui-autocomplete-results':
+              filteredItems.length > 0 || !allowCustom,
+          }"
           :unmount="!portal"
         >
           <!-- Placeholder -->
@@ -557,7 +548,7 @@ function key(item: T) {
             </slot>
           </div>
           <div
-            v-else-if="filteredItems.length === 0"
+            v-else-if="filteredItems.length === 0 && !allowCustom"
             class="nui-autocomplete-results-placeholder"
           >
             <slot
@@ -584,6 +575,14 @@ function key(item: T) {
                 }"
               ></slot>
             </div>
+            <ComboboxOption
+              v-if="allowCustom && queryCustom"
+              :value="queryCustom"
+              class="hidden"
+              as="div"
+            >
+              Create {{ query }}
+            </ComboboxOption>
             <ComboboxOption
               v-for="item in filteredItems"
               v-slot="{ active, selected }"

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -252,7 +252,7 @@ const props = withDefaults(
     allowCustom: false,
     fixed: false,
     placement: 'bottom-start',
-    properties: () => ({}),
+    properties: undefined,
   },
 )
 

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -172,12 +172,7 @@ const props = withDefaults(
     /**
      * Allow custom entries by the user
      */
-    allowCustom?: boolean
-
-    /**
-     * Hide the create custom prompt (just set the model to the value entered)
-     */
-    hideCustomPrompt?: boolean
+    allowCreate?: boolean
 
     /**
      * Used a fixed strategy to float the component
@@ -260,8 +255,7 @@ const props = withDefaults(
     filterDebounce: 0,
     filterItems: undefined,
     classes: () => ({}),
-    allowCustom: false,
-    hideCustomPrompt: false,
+    allowCreate: false,
     fixed: false,
     placement: 'bottom-start',
     properties: undefined,
@@ -358,7 +352,7 @@ const pendingFilter = ref(false)
 const pendingDebounce = computed(() => query.value !== debounced.value)
 const pending = computed(() => pendingFilter.value || pendingDebounce.value)
 
-const queryCustom = computed(() => {
+const queryCreate = computed(() => {
   return query.value === '' ? null : query.value
 })
 
@@ -640,7 +634,7 @@ function key(item: T) {
           as="div"
           :class="{
             'nui-autocomplete-results':
-              filteredItems.length > 0 || !hideCustomPrompt,
+              filteredItems.length > 0 || !allowCreate,
           }"
         >
           <!-- Placeholder -->
@@ -658,7 +652,7 @@ function key(item: T) {
             </slot>
           </div>
           <div
-            v-else-if="filteredItems.length === 0 && !allowCustom"
+            v-else-if="filteredItems.length === 0 && !allowCreate"
             class="nui-autocomplete-results-placeholder"
           >
             <slot
@@ -686,14 +680,26 @@ function key(item: T) {
               ></slot>
             </div>
             <ComboboxOption
-              v-if="allowCustom && queryCustom"
-              :value="queryCustom"
+              v-if="allowCreate && queryCreate"
+              :value="queryCreate"
+              v-slot="{ active, selected }"
               as="div"
-              :class="
-                hideCustomPrompt ? 'hidden' : 'nui-autocomplete-results-item'
-              "
             >
-              Create {{ query }}
+              <slot
+                name="create-item"
+                v-bind="{
+                  query,
+                  filteredItems,
+                  pending,
+                  items,
+                  active,
+                  selected,
+                }"
+              >
+                <span class="nui-autocomplete-results-item">
+                  Create {{ query }}
+                </span>
+              </slot>
             </ComboboxOption>
             <ComboboxOption
               v-for="item in filteredItems"
@@ -759,18 +765,5 @@ function key(item: T) {
 .nui-autocomplete .nui-autocomplete-results {
   position: unset;
   margin-top: unset;
-}
-
-:is(.dark .nui-autocomplete-chevron) {
-  --tw-border-opacity: 1;
-  border-color: rgb(51 65 85 / 1);
-  border-color: rgb(51 65 85 / var(--tw-border-opacity));
-  border-inline-start-width: 1px;
-}
-.nui-autocomplete-chevron {
-  --tw-border-opacity: 1;
-  border-color: rgb(226 232 240 / 1);
-  border-color: rgb(226 232 240 / var(--tw-border-opacity));
-  border-inline-start-width: 1px;
 }
 </style>

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -554,7 +554,11 @@ function key(item: T) {
         <div class="nui-autocomplete-outer">
           <ComboboxInput
             class="nui-autocomplete-input"
-            :class="[classes?.input, props.dropdown && '!pe-8']"
+            :class="[
+              classes?.input,
+              props.dropdown && !props.clearable && '!pe-12',
+              props.dropdown && props.clearable && '!pe-[4.5rem]',
+            ]"
             :display-value="
               props.multiple ? undefined : (displayValueResolved as any)
             "
@@ -584,8 +588,13 @@ function key(item: T) {
             </slot>
           </div>
           <button
-            v-if="props.clearable && vmodel && vmodel?.length > 0"
+            v-if="
+              props.clearable &&
+              ((Array.isArray(vmodel) && vmodel?.length > 0) ||
+                (!Array.isArray(vmodel) && vmodel != null))
+            "
             type="button"
+            tabindex="-1"
             class="nui-autocomplete-clear"
             :class="[props.classes?.icon, props.dropdown && 'me-10']"
             @click="clear"

--- a/components/form/BaseAutocomplete.vue
+++ b/components/form/BaseAutocomplete.vue
@@ -155,6 +155,44 @@ const props = withDefaults(
        */
       icon?: string | string[]
     }
+    /**
+     * Allow custom entries by the user
+     */
+    allowCustom?: boolean
+
+    /**
+     * Portal the dropdown to body
+     */
+    portal?: boolean
+
+    /**
+     * The properties to use for the value, label, sublabel, media, and icon of the options items.
+     */
+    properties?: {
+      /**
+       * The property to use for the key of the options.
+       */
+      key?: T extends object ? keyof T | ((arg: T) => string) : string
+      /**
+       * The property to use for the label of the options.
+       */
+      label?: T extends object ? keyof T | ((arg: T) => string) : string
+
+      /**
+       * The property to use for the sublabel of the options.
+       */
+      sublabel?: T extends object ? keyof T | ((arg: T) => string) : string
+
+      /**
+       * The property to use for the media of the options.
+       */
+      media?: T extends object ? keyof T | ((arg: T) => string) : string
+
+      /**
+       * The property to use for the icon of the options.
+       */
+      icon?: T extends object ? keyof T | ((arg: T) => string) : string
+    }
   }>(),
   {
     modelValue: undefined,
@@ -194,6 +232,9 @@ const props = withDefaults(
       })
     },
     classes: () => ({}),
+    allowCustom: false,
+    portal: false,
+    properties: undefined,
   },
 )
 
@@ -337,6 +378,16 @@ function removeItem(item: any) {
     }
   }
 }
+
+function key(item: T) {
+  if (props.properties == null) return props.displayValue(item)
+  if (typeof props.properties.key === 'string')
+    return (item as any)[props.properties.key]
+  if (typeof props.properties.key === 'function')
+    //@ts-expect-error not sure why properties.key ends up undefined
+    return props.properties.key(item as any)
+  return props.displayValue(item)
+}
 </script>
 
 <template>
@@ -364,6 +415,8 @@ function removeItem(item: any) {
       @hide="query = ''"
       :flip="!props.multiple"
       :offset="5"
+      :portal="props.portal"
+      :adaptive-width="props.portal"
       :z-index="20"
     >
       <ComboboxLabel
@@ -475,7 +528,15 @@ function removeItem(item: any) {
       >
         {{ props.error }}
       </span>
-      <FloatContent class="w-full">
+      <FloatContent
+        :class="[
+          !props.portal && 'w-full',
+          props.portal && 'nui-autocomplete',
+          props.portal && sizeStyle[props.size],
+          props.portal && contrastStyle[props.contrast],
+          props.portal && shape && shapeStyle[shape],
+        ]"
+      >
         <ComboboxOptions as="div" class="nui-autocomplete-results">
           <!-- Placeholder -->
           <div
@@ -522,7 +583,7 @@ function removeItem(item: any) {
             <ComboboxOption
               v-for="item in filteredItems"
               v-slot="{ active, selected }"
-              :key="props.displayValue(item)"
+              :key="key(item)"
               class="nui-autocomplete-results-item"
               as="div"
               :value="item as any"
@@ -541,15 +602,16 @@ function removeItem(item: any) {
               >
                 <BaseAutocompleteItem
                   :shape="shape"
-                  :value="
-                    isAutocompleteItem(item)
+                  :item="
+                    properties
                       ? item
-                      : {
-                          name: props.displayValue(item),
-                        }
+                      : ({
+                          label: props.displayValue(item),
+                        } as T)
                   "
                   :active="active"
                   :selected="selected"
+                  :properties="properties"
                 />
               </slot>
             </ComboboxOption>

--- a/components/form/BaseAutocompleteItem.vue
+++ b/components/form/BaseAutocompleteItem.vue
@@ -60,7 +60,13 @@ const props = withDefaults(
     mark: 'nui-mark',
     selectedIcon: 'lucide:check',
     item: undefined,
-    properties: undefined,
+    properties: () =>
+      ({
+        label: 'label',
+        sublabel: 'sublabel',
+        media: 'media',
+        icon: 'icon',
+      }) as any,
   },
 )
 

--- a/components/form/BaseListbox.vue
+++ b/components/form/BaseListbox.vue
@@ -129,6 +129,10 @@ const props = withDefaults(
        */
       icon?: T extends object ? keyof T : string
     }
+    /**
+     * Portal the dropdown to body
+     */
+    portal?: boolean
   }>(),
   {
     icon: '',
@@ -157,6 +161,7 @@ const props = withDefaults(
     loading: false,
     disabled: false,
     properties: () => ({}),
+    portal: false,
   },
 )
 const emits = defineEmits<{
@@ -241,6 +246,8 @@ const value = computed(() => {
         leave-to-class="opacity-0"
         flip
         :offset="5"
+        :portal="props.portal"
+        :adaptive-width="props.portal"
         :z-index="20"
       >
         <ListboxLabel
@@ -359,8 +366,16 @@ const value = computed(() => {
             </ListboxButton>
           </FloatReference>
 
-          <FloatContent class="w-full">
-            <ListboxOptions class="nui-listbox-options">
+          <FloatContent
+            :class="[
+              !props.portal && 'w-full',
+              props.portal && 'nui-listbox',
+              props.portal && sizeStyle[props.size],
+              props.portal && contrastStyle[props.contrast],
+              props.portal && shape && shapeStyle[shape],
+            ]"
+          >
+            <ListboxOptions class="nui-listbox-options" :unmount="!portal">
               <ListboxOption
                 v-for="item in props.items"
                 v-slot="{ active, selected }"

--- a/components/form/BaseListbox.vue
+++ b/components/form/BaseListbox.vue
@@ -101,6 +101,28 @@ const props = withDefaults(
     contrast?: 'default' | 'default-contrast' | 'muted' | 'muted-contrast'
 
     /**
+     * Used a fixed strategy to float the component
+     */
+    fixed?: boolean
+
+    /**
+     * The placement of the component via floating-ui.
+     */
+    placement?:
+      | 'top'
+      | 'top-start'
+      | 'top-end'
+      | 'right'
+      | 'right-start'
+      | 'right-end'
+      | 'bottom'
+      | 'bottom-start'
+      | 'bottom-end'
+      | 'left'
+      | 'left-start'
+      | 'left-end'
+
+    /**
      * The properties to use for the value, label, sublabel, media, and icon of the options items.
      */
     properties?: {
@@ -129,10 +151,6 @@ const props = withDefaults(
        */
       icon?: T extends object ? keyof T : string
     }
-    /**
-     * Portal the dropdown to body
-     */
-    portal?: boolean
   }>(),
   {
     icon: '',
@@ -161,7 +179,8 @@ const props = withDefaults(
     loading: false,
     disabled: false,
     properties: () => ({}),
-    portal: false,
+    fixed: false,
+    placement: 'bottom-start',
   },
 )
 const emits = defineEmits<{
@@ -246,8 +265,9 @@ const value = computed(() => {
         leave-to-class="opacity-0"
         flip
         :offset="5"
-        :portal="props.portal"
-        :adaptive-width="props.portal"
+        :strategy="props.fixed ? 'fixed' : 'absolute'"
+        :placement="props.placement"
+        :adaptive-width="props.fixed"
         :z-index="20"
       >
         <ListboxLabel
@@ -262,120 +282,114 @@ const value = computed(() => {
 
         <div class="nui-listbox-outer">
           <FloatReference>
-            <ListboxButton
-              :disabled="props.disabled"
-              class="nui-listbox-button"
-            >
-              <slot name="listbox-button" :value="value" :open="open">
-                <div class="nui-listbox-button-inner">
-                  <BaseIconBox
-                    v-if="props.icon"
-                    size="xs"
-                    shape="rounded"
-                    class="nui-icon-box"
-                  >
-                    <slot name="icon">
-                      <Icon :name="props.icon" class="nui-icon-box-inner" />
-                    </slot>
-                  </BaseIconBox>
-
-                  <template v-if="Array.isArray(value)">
-                    <div
-                      v-if="value.length === 0 && placeholder"
-                      class="nui-listbox-placeholder"
-                      :class="props.loading && 'text-transparent select-none'"
-                    >
-                      {{ placeholder }}
-                    </div>
-                    <div
-                      class="block truncate text-left"
-                      :class="[
-                        props.loading && 'select-none text-transparent',
-                        value.length === 0 &&
-                          'text-muted-300 dark:text-muted-500',
-                      ]"
-                    >
-                      {{
-                        typeof props.multipleLabel === 'function'
-                          ? props.multipleLabel(value, props.properties.label)
-                          : props.multipleLabel
-                      }}
-                    </div>
-                  </template>
-
-                  <template v-else-if="value">
-                    <BaseAvatar
-                      v-if="
-                        props.properties.media &&
-                        (value as any)[props.properties.media]
-                      "
-                      :src="(value as any)[props.properties.media]"
-                      size="xs"
-                      class="-ms-2 me-2"
-                    />
+            <div>
+              <ListboxButton
+                :disabled="props.disabled"
+                class="nui-listbox-button"
+              >
+                <slot name="listbox-button" :value="value" :open="open">
+                  <div class="nui-listbox-button-inner">
                     <BaseIconBox
-                      v-else-if="
-                        props.properties.icon &&
-                        (value as any)[props.properties.icon]
-                      "
+                      v-if="props.icon"
                       size="xs"
                       shape="rounded"
-                      class="-ms-2 me-2"
+                      class="nui-icon-box"
                     >
-                      <Icon
-                        :name="(value as any)[props.properties.icon]"
-                        class="h-4 w-4"
-                      />
+                      <slot name="icon">
+                        <Icon :name="props.icon" class="nui-icon-box-inner" />
+                      </slot>
                     </BaseIconBox>
-                    <div
-                      class="truncate text-left"
-                      :class="props.loading && 'text-transparent select-none'"
-                    >
-                      {{
-                        props.properties.label
-                          ? (value as any)[props.properties.label]
-                          : props.properties.value
-                          ? (value as any)[props.properties.value]
-                          : value
-                      }}
+
+                    <template v-if="Array.isArray(value)">
+                      <div
+                        v-if="value.length === 0 && placeholder"
+                        class="nui-listbox-placeholder"
+                        :class="props.loading && 'select-none text-transparent'"
+                      >
+                        {{ placeholder }}
+                      </div>
+                      <div
+                        class="block truncate text-left"
+                        :class="[
+                          props.loading && 'select-none text-transparent',
+                          value.length === 0 &&
+                            'text-muted-300 dark:text-muted-500',
+                        ]"
+                      >
+                        {{
+                          typeof props.multipleLabel === 'function'
+                            ? props.multipleLabel(value, props.properties.label)
+                            : props.multipleLabel
+                        }}
+                      </div>
+                    </template>
+
+                    <template v-else-if="value">
+                      <BaseAvatar
+                        v-if="
+                          props.properties.media &&
+                          (value as any)[props.properties.media]
+                        "
+                        :src="(value as any)[props.properties.media]"
+                        size="xs"
+                        class="-ms-2 me-2"
+                      />
+                      <BaseIconBox
+                        v-else-if="
+                          props.properties.icon &&
+                          (value as any)[props.properties.icon]
+                        "
+                        size="xs"
+                        shape="rounded"
+                        class="-ms-2 me-2"
+                      >
+                        <Icon
+                          :name="(value as any)[props.properties.icon]"
+                          class="h-4 w-4"
+                        />
+                      </BaseIconBox>
+                      <div
+                        class="truncate text-left"
+                        :class="props.loading && 'select-none text-transparent'"
+                      >
+                        {{
+                          props.properties.label
+                            ? (value as any)[props.properties.label]
+                            : props.properties.value
+                            ? (value as any)[props.properties.value]
+                            : value
+                        }}
+                      </div>
+                    </template>
+
+                    <template v-else>
+                      <div
+                        class="nui-listbox-placeholder"
+                        :class="props.loading && 'select-none text-transparent'"
+                      >
+                        {{ placeholder }}
+                      </div>
+                    </template>
+
+                    <span class="nui-listbox-chevron">
+                      <Icon
+                        name="lucide:chevron-down"
+                        class="nui-listbox-chevron-inner"
+                        :class="[open && 'rotate-180']"
+                      />
+                    </span>
+
+                    <div v-if="props.loading" class="nui-listbox-placeload">
+                      <BasePlaceload class="nui-placeload" />
                     </div>
-                  </template>
-
-                  <template v-else>
-                    <div
-                      class="nui-listbox-placeholder"
-                      :class="props.loading && 'text-transparent select-none'"
-                    >
-                      {{ placeholder }}
-                    </div>
-                  </template>
-
-                  <span class="nui-listbox-chevron">
-                    <Icon
-                      name="lucide:chevron-down"
-                      class="nui-listbox-chevron-inner"
-                      :class="[open && 'rotate-180']"
-                    />
-                  </span>
-
-                  <div v-if="props.loading" class="nui-listbox-placeload">
-                    <BasePlaceload class="nui-placeload" />
                   </div>
-                </div>
-              </slot>
-            </ListboxButton>
+                </slot>
+              </ListboxButton>
+            </div>
           </FloatReference>
 
-          <FloatContent
-            :class="[
-              !props.portal && 'w-full',
-              props.portal && 'nui-listbox',
-              props.portal && sizeStyle[props.size],
-              props.portal && contrastStyle[props.contrast],
-              props.portal && shape && shapeStyle[shape],
-            ]"
-          >
-            <ListboxOptions class="nui-listbox-options" :unmount="!portal">
+          <FloatContent :class="!props.fixed && 'w-full'">
+            <ListboxOptions class="nui-listbox-options">
               <ListboxOption
                 v-for="item in props.items"
                 v-slot="{ active, selected }"


### PR DESCRIPTION
This is my attempt to improve the BaseAutocomplete and BaseAutocompleteItem

I added:
- the allowCustom from #100 
- ability to use fixed for the floating dropdown (I needed this in modals)
- made the BaseAutocompleteItem more generic and consistent with the BaseListbox

You should have edit permissions on this fork; open to ideas / suggestions.

I originally tried portals, but they seem to be very unreliable for multiple portalled elements and they also added styling challenges.  I was able to fix my problems that started this with fixed positioning rather than portalled.
