### PR TITLE
refactor(tailwind-config): provide config through tailwind.config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,4 @@
 import { createResolver } from '@nuxt/kit'
-import { withShurikenUI } from '@shuriken-ui/tailwind'
 
 const { resolve } = createResolver(import.meta.url)
 
@@ -32,13 +31,6 @@ export default defineNuxtConfig({
       global: false,
     },
   ],
-
-  hooks: {
-    // @ts-expect-error - hook is handled by nuxtjs/tailwindcss
-    'tailwindcss:config'(config: Config) {
-      withShurikenUI(config)
-    },
-  },
 
   devtools: {
     enabled: false,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,3 @@
+import { withShurikenUI } from '@shuriken-ui/tailwind'
+
+export default withShurikenUI({ content: [] })


### PR DESCRIPTION
This change should allow the layer to be used with instant HMR enabled in 6.12.0 release of `@nuxtjs/tailwindcss`.

I've updated this PR to the best of my knowledge from what I could understand about `@shuriken-ui/tailwind` (I see that it provides the config under `presets`, so we should be fine), but for a layer, it is always best to provide the config using a separate config file. Let me know if there's anything missing. 🙂 